### PR TITLE
fix: don't infer prefix from client id

### DIFF
--- a/src/clients/BaseIbcClient.ts
+++ b/src/clients/BaseIbcClient.ts
@@ -160,7 +160,7 @@ export abstract class BaseIbcClient<T extends IbcClientTypes = IbcClientTypes> {
   abstract updateGnoClient(clientId: string, header: ibc.lightclients.gno.v1.gno.Header): Promise<MsgResult>;
 
   /* Registering counterparty client for IBC v2 handshaking  Tx */
-  abstract registerCounterParty(clientId: string, counterpartyClientId: string, merklePrefix: Uint8Array): Promise<MsgResult>;
+  abstract registerCounterParty(clientId: string, counterpartyClientId: string, merklePrefix: Uint8Array, merklePathPrefix?: Uint8Array): Promise<MsgResult>;
 
   /* Connection and channel handling for IBC v1 handshaking Txs */
   abstract connOpenInit(clientId: string, remoteClientId: string): Promise<CreateConnectionResult>;

--- a/src/clients/gno/IbcClient.ts
+++ b/src/clients/gno/IbcClient.ts
@@ -1197,7 +1197,7 @@ export class GnoIbcClient extends BaseIbcClient<GnoIbcClientTypes> {
     };
   }
 
-  public async registerCounterParty(clientId: string, counterpartyClientId: string, merklePrefix: Uint8Array): Promise<MsgResult> {
+  public async registerCounterParty(clientId: string, counterpartyClientId: string, merklePrefix: Uint8Array, _merklePathPrefix?: Uint8Array): Promise<MsgResult> {
     this.logger.verbose(
       `Register Counterparty : ${counterpartyClientId} => ${clientId}`,
     );

--- a/src/clients/tendermint/IbcClient.ts
+++ b/src/clients/tendermint/IbcClient.ts
@@ -1680,18 +1680,11 @@ export class TendermintIbcClient extends BaseIbcClient<TendermintIbcClientTypes>
     };
   }
 
-  public async registerCounterParty(clientId: string, counterpartyClientId: string, merklePrefix: Uint8Array): Promise<MsgResult> {
+  public async registerCounterParty(clientId: string, counterpartyClientId: string, merklePrefix: Uint8Array, merklePathPrefix: Uint8Array = new Uint8Array()): Promise<MsgResult> {
     this.logger.verbose(
       `Register Counterparty : ${counterpartyClientId} => ${clientId}`,
     );
     const senderAddress = this.senderAddress;
-    let merklePathPrefix: Uint8Array;
-    if (clientId.startsWith("10-gno-")) {
-      merklePathPrefix = toAscii("/pv/vm:gno.land/r/aib/ibc/core:");
-    }
-    else {
-      merklePathPrefix = new Uint8Array();
-    }
     const msg = {
       typeUrl: "/ibc.core.client.v2.MsgRegisterCounterparty",
       value: MsgRegisterCounterparty.fromPartial({

--- a/src/links/v2/link.ts
+++ b/src/links/v2/link.ts
@@ -180,14 +180,18 @@ export class Link {
     await Promise.all([nodeA.waitOneBlock(), nodeB.waitOneBlock()]);
     let merklePrefixA = Buffer.from("ibc", "utf-8");
     let merklePrefixB = Buffer.from("ibc", "utf-8");
+    let merklePathPrefixA = new Uint8Array();
+    let merklePathPrefixB = new Uint8Array();
     if (isGno(nodeA)) {
       merklePrefixA = Buffer.from("main", "utf-8");
+      merklePathPrefixA = Buffer.from("/pv/vm:gno.land/r/aib/ibc/core:", "utf-8");
     }
     if (isGno(nodeB)) {
       merklePrefixB = Buffer.from("main", "utf-8");
+      merklePathPrefixB = Buffer.from("/pv/vm:gno.land/r/aib/ibc/core:", "utf-8");
     }
-    await nodeB.registerCounterParty(clientIdB, clientIdA, merklePrefixA);
-    await nodeA.registerCounterParty(clientIdA, clientIdB, merklePrefixB);
+    await nodeB.registerCounterParty(clientIdB, clientIdA, merklePrefixA, merklePathPrefixA);
+    await nodeA.registerCounterParty(clientIdA, clientIdB, merklePrefixB, merklePathPrefixB);
     const endA = getEndpoint(nodeA, clientIdA);
     const endB = getEndpoint(nodeB, clientIdB);
     return new Link(endA, endB, logger);


### PR DESCRIPTION
Compute merkle path prefix from chain type, not client ID