### PR TITLE
fix(e2e): whitelist relayer before gno tests

### DIFF
--- a/docker/chains/gno/Dockerfile
+++ b/docker/chains/gno/Dockerfile
@@ -2,8 +2,8 @@ FROM        golang:1.25-alpine
 ENV         CGO_ENABLED=0 GOOS=linux
 WORKDIR     /app
 RUN        apk add --no-cache git
-ADD        https://api.github.com/repos/tbruyelle/gno/git/refs/heads/ibc-fork /dev/null
-RUN        git clone --depth 1 --branch ibc-fork https://github.com/tbruyelle/gno.git
+ADD        https://api.github.com/repos/allinbits/gno/git/refs/heads/ibc-fork /dev/null
+RUN        git clone --depth 1 --branch ibc-fork https://github.com/allinbits/gno.git
 WORKDIR     /app
 ADD        https://api.github.com/repos/allinbits/gno-realms/git/refs/heads/master /dev/null
 RUN        git clone --depth 1 --branch master https://github.com/allinbits/gno-realms.git

--- a/docker/chains/gno/Dockerfile
+++ b/docker/chains/gno/Dockerfile
@@ -6,9 +6,8 @@ RUN        git clone https://github.com/tbruyelle/gno.git
 WORKDIR     /app/gno
 RUN        git checkout tbruyelle/origin-send-filter
 WORKDIR     /app
-RUN        git clone https://github.com/allinbits/gno-realms.git
-WORKDIR     /app/gno-realms
-RUN        git checkout master
+ADD        https://api.github.com/repos/allinbits/gno-realms/git/refs/heads/master /dev/null
+RUN        git clone --depth 1 --branch master https://github.com/allinbits/gno-realms.git
 WORKDIR     /app/gno-realms
 RUN         cp -R ./gno.land/* /app/gno/examples/gno.land
 WORKDIR     /app/gno/contribs/gnodev

--- a/docker/chains/gno/Dockerfile
+++ b/docker/chains/gno/Dockerfile
@@ -2,9 +2,8 @@ FROM        golang:1.25-alpine
 ENV         CGO_ENABLED=0 GOOS=linux
 WORKDIR     /app
 RUN        apk add --no-cache git
-RUN        git clone https://github.com/tbruyelle/gno.git
-WORKDIR     /app/gno
-RUN        git checkout tbruyelle/origin-send-filter
+ADD        https://api.github.com/repos/tbruyelle/gno/git/refs/heads/ibc-fork /dev/null
+RUN        git clone --depth 1 --branch ibc-fork https://github.com/tbruyelle/gno.git
 WORKDIR     /app
 ADD        https://api.github.com/repos/allinbits/gno-realms/git/refs/heads/master /dev/null
 RUN        git clone --depth 1 --branch master https://github.com/allinbits/gno-realms.git

--- a/e2e/gno.e2e.ts
+++ b/e2e/gno.e2e.ts
@@ -13,6 +13,10 @@ import {
 } from "vitest";
 
 import {
+  setupGnoWhitelist,
+} from "./setup.ts";
+
+import {
   Relayer,
 } from "../src/relayer";
 import {
@@ -39,6 +43,8 @@ const init = async () => {
   await relayer.addGasPrice("dev", "0.025", "ugnot");
   await relayer.addNewRelayPath("ibctest-1", "http://localhost:56657", undefined, "dev", "http://localhost:46657", "http://localhost:8546/graphql/query", ChainType.Cosmos, ChainType.Gno, 2);
 };
+
+setupGnoWhitelist();
 
 test("Start relayer and. run E2E tests", async () => {
   await init();

--- a/e2e/setup.ts
+++ b/e2e/setup.ts
@@ -1,0 +1,38 @@
+import {
+  GnoJSONRPCProvider,
+  GnoWallet,
+} from "@gnolang/gno-js-client";
+import {
+  TransactionEndpoint,
+} from "@gnolang/tm2-js-client";
+import {
+  beforeAll,
+} from "vitest";
+
+// gnodev deploys realms with test1 as DefaultCreator, making it the core realm admin
+const TEST1_SEED = "source bonus chronic canvas draft south burst lottery vacant surface solve popular case indicate oppose farm nothing bullet exhibit title speed wink action roast";
+
+export function setupGnoWhitelist(gnoUrl = "http://localhost:46657") {
+  beforeAll(async () => {
+    const mnemonic = process.env.RELAYER_MNEMONIC ?? "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    const relayerWallet = await GnoWallet.fromMnemonic(mnemonic, { addressPrefix: "g" });
+    const relayerAddr = await relayerWallet.getAddress();
+
+    const provider = await GnoJSONRPCProvider.create(gnoUrl);
+    const test1Wallet = await GnoWallet.fromMnemonic(TEST1_SEED, { addressPrefix: "g" });
+    test1Wallet.connect(provider);
+
+    await test1Wallet.callMethod(
+      "gno.land/r/aib/ibc/core",
+      "AddRelayer",
+      [relayerAddr],
+      TransactionEndpoint.BROADCAST_TX_COMMIT,
+      new Map(),
+      (new Map()).set("ugnot", 1000000),
+      {
+        gas_wanted: 90000000n,
+        gas_fee: "1000000ugnot",
+      },
+    );
+  });
+}

--- a/e2e/txs.e2e.ts
+++ b/e2e/txs.e2e.ts
@@ -45,6 +45,9 @@ import {
 import {
   ChainFees,
 } from "../src/types/index.ts";
+import {
+  setupGnoWhitelist,
+} from "./setup.ts";
 
 function ibcRegistry(): Registry {
   return new Registry([...defaultRegistryTypes, ["/ibc.core.channel.v2.MsgSendPacket", MsgSendPacket as GeneratedType]]);
@@ -122,6 +125,8 @@ export const transferFromTm = async (clientId: string, sender: string, receiver:
   return result;
 };
 describe("IBC Transfer Tests", async () => {
+  setupGnoWhitelist();
+
   const _marsClient = await connectComet("http://localhost:26657");
   const venusClient = await connectComet("http://localhost:36657");
   const atoneClient = await connectComet("http://localhost:56657");

--- a/src/clients/gno/IbcClient.ts
+++ b/src/clients/gno/IbcClient.ts
@@ -636,8 +636,8 @@ export class GnoIbcClient extends BaseIbcClient<GnoIbcClientTypes> {
 
     const result = await this.sign.executePackage(memPackage, TransactionEndpoint.BROADCAST_TX_COMMIT, new Map(), (new Map()).set("ugnot", GNO_DEFAULT_DEPOSIT),
       {
-        gas_wanted: 50000000n,
-        gas_fee: "750000ugnot",
+        gas_wanted: 100000000n,
+        gas_fee: "1500000ugnot",
       });
 
     if (result.deliver_tx.ResponseBase.Error) {
@@ -731,8 +731,8 @@ export class GnoIbcClient extends BaseIbcClient<GnoIbcClientTypes> {
 
     const result = await this.sign.executePackage(memPackage, TransactionEndpoint.BROADCAST_TX_COMMIT, new Map(), (new Map()).set("ugnot", GNO_DEFAULT_DEPOSIT),
       {
-        gas_wanted: 100000000n,
-        gas_fee: "100000ugnot",
+        gas_wanted: 200000000n,
+        gas_fee: "200000ugnot",
       });
 
     if (result.deliver_tx.ResponseBase.Error) {
@@ -913,8 +913,8 @@ export class GnoIbcClient extends BaseIbcClient<GnoIbcClientTypes> {
       );
     }
     const txFee: TxFee = {
-      gas_wanted: 80000000n * BigInt(packets.length),
-      gas_fee: Math.floor(80000000 * packets.length / 1000) + "ugnot",
+      gas_wanted: 160000000n * BigInt(packets.length),
+      gas_fee: Math.floor(160000000 * packets.length / 1000) + "ugnot",
     };
 
     const tx: Tx = {
@@ -1020,8 +1020,8 @@ export class GnoIbcClient extends BaseIbcClient<GnoIbcClientTypes> {
       );
     }
     const txFee: TxFee = {
-      gas_wanted: BigInt(70000000 * acks.length),
-      gas_fee: Math.floor(70000000 * acks.length / 1000) + "ugnot",
+      gas_wanted: BigInt(140000000 * acks.length),
+      gas_fee: Math.floor(140000000 * acks.length / 1000) + "ugnot",
     };
 
     const tx: Tx = {
@@ -1132,8 +1132,8 @@ export class GnoIbcClient extends BaseIbcClient<GnoIbcClientTypes> {
       );
     }
     const txFee: TxFee = {
-      gas_wanted: 60000000n * BigInt(packets.length),
-      gas_fee: Math.floor(60000000 * packets.length / 1000) + "ugnot",
+      gas_wanted: 120000000n * BigInt(packets.length),
+      gas_fee: Math.floor(120000000 * packets.length / 1000) + "ugnot",
     };
 
     const tx: Tx = {
@@ -1220,8 +1220,8 @@ export class GnoIbcClient extends BaseIbcClient<GnoIbcClientTypes> {
 
     const result = await this.sign.executePackage(memPackage, TransactionEndpoint.BROADCAST_TX_COMMIT, new Map(), (new Map()).set("ugnot", GNO_DEFAULT_DEPOSIT),
       {
-        gas_wanted: 50000000n,
-        gas_fee: "75000ugnot",
+        gas_wanted: 100000000n,
+        gas_fee: "150000ugnot",
       });
 
     if (result.deliver_tx.ResponseBase.Error) {


### PR DESCRIPTION
CreateClient and all packet relay operations on gno.land/r/aib/ibc/core now require the relayer to be authorized. Add a shared setupGnoWhitelist() helper that registers the relayer address via the test1 admin account before tests run.

Related PR: https://github.com/allinbits/gno-realms/pull/35